### PR TITLE
Replace GetValueOrDefault with specific extension methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,15 @@ Option<int> option = ...
 // Explicit check
 if (option.IsSome)
 {
-    return option.Value;
+    int value = option.Value;
+	...
 }
-else
-{
-    return -1;
-}
-
-// Using GetValueOrDefault
-return option.GetValueOrDefault(-1);
 
 // Using TryGetValue
-return option.TryGetValue(out var value) ? value : -1;
+if (option.TryGetValue(out var value))
+{
+    ...
+}
 ```
 
 ### Usage with Linq

--- a/src/Hamlet/NullableAttributes.cs
+++ b/src/Hamlet/NullableAttributes.cs
@@ -1,0 +1,7 @@
+﻿namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute
+    { }
+}

--- a/src/Hamlet/Option.cs
+++ b/src/Hamlet/Option.cs
@@ -148,8 +148,8 @@ namespace Hamlet
         /// <typeparam name="T">The type of the option's value.</typeparam>
         /// <param name="option">The option to get the value from.</param>
         /// <returns>The option's value if it's <c>Some</c>, or <c>null</c> if it's <c>None</c>.</returns>
-        public static T? ValueOrNull<T>(this Option<T> option)
-            where T : class
+        public static T ValueOrNull<T>(this Option<T> option)
+            where T : class?
         {
             return option.IsSome
                 ? option.Value

--- a/src/Hamlet/Option.cs
+++ b/src/Hamlet/Option.cs
@@ -143,6 +143,49 @@ namespace Hamlet
         }
 
         /// <summary>
+        /// Returns the value of an <see cref="Option{T}"/> if the option is <c>Some</c>, or <c>null</c> if it's <c>None</c>.
+        /// </summary>
+        /// <typeparam name="T">The type of the option's value.</typeparam>
+        /// <param name="option">The option to get the value from.</param>
+        /// <returns>The option's value if it's <c>Some</c>, or <c>null</c> if it's <c>None</c>.</returns>
+        public static T? GetValueOrNull<T>(this Option<T> option)
+            where T : class
+        {
+            return option.IsSome
+                ? option.Value
+                : null;
+        }
+
+        /// <summary>
+        /// Returns the value of an <see cref="Option{T}"/> if the option is <c>Some</c>, or <c>default(T)</c> if it's <c>None</c>.
+        /// </summary>
+        /// <typeparam name="T">The type of the option's value.</typeparam>
+        /// <param name="option">The option to get the value from.</param>
+        /// <returns>The option's value if it's <c>Some</c>, or <c>default(T)</c> if it's <c>None</c>.</returns>
+        public static T GetValueOrDefault<T>(this Option<T> option)
+            where T : struct
+        {
+            return option.IsSome
+                ? option.Value
+                : default;
+        }
+
+        /// <summary>
+        /// Returns the value of an <see cref="Option{T}"/> if the option is <c>Some</c>, or <c>defaultValue</c> if it's <c>None</c>.
+        /// </summary>
+        /// <typeparam name="T">The type of the option's value.</typeparam>
+        /// <param name="option">The option to get the value from.</param>
+        /// <param name="defaultValue">The value to return if the option is <c>None</c>.</param>
+        /// <returns>The option's value if it's <c>Some</c>, or <c>defaultValue</c> if it's <c>None</c>.</returns>
+        public static T GetValueOr<T>(this Option<T> option, T defaultValue)
+            where T : struct
+        {
+            return option.IsSome
+                ? option.Value
+                : defaultValue;
+        }
+
+        /// <summary>
         /// Converts a <see cref="Nullable{T}"/> to an <see cref="Option{T}"/>, based on whether the nullable has a value.
         /// </summary>
         /// <typeparam name="T">The type of the nullable's value.</typeparam>

--- a/src/Hamlet/Option.cs
+++ b/src/Hamlet/Option.cs
@@ -148,7 +148,7 @@ namespace Hamlet
         /// <typeparam name="T">The type of the option's value.</typeparam>
         /// <param name="option">The option to get the value from.</param>
         /// <returns>The option's value if it's <c>Some</c>, or <c>null</c> if it's <c>None</c>.</returns>
-        public static T? GetValueOrNull<T>(this Option<T> option)
+        public static T? ValueOrNull<T>(this Option<T> option)
             where T : class
         {
             return option.IsSome
@@ -162,7 +162,7 @@ namespace Hamlet
         /// <typeparam name="T">The type of the option's value.</typeparam>
         /// <param name="option">The option to get the value from.</param>
         /// <returns>The option's value if it's <c>Some</c>, or <c>default(T)</c> if it's <c>None</c>.</returns>
-        public static T GetValueOrDefault<T>(this Option<T> option)
+        public static T ValueOrDefault<T>(this Option<T> option)
             where T : struct
         {
             return option.IsSome
@@ -177,8 +177,7 @@ namespace Hamlet
         /// <param name="option">The option to get the value from.</param>
         /// <param name="defaultValue">The value to return if the option is <c>None</c>.</param>
         /// <returns>The option's value if it's <c>Some</c>, or <c>defaultValue</c> if it's <c>None</c>.</returns>
-        public static T GetValueOr<T>(this Option<T> option, T defaultValue)
-            where T : struct
+        public static T ValueOr<T>(this Option<T> option, T defaultValue)
         {
             return option.IsSome
                 ? option.Value

--- a/src/Hamlet/Option.cs
+++ b/src/Hamlet/Option.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Hamlet
 {
@@ -148,6 +149,7 @@ namespace Hamlet
         /// <typeparam name="T">The type of the option's value.</typeparam>
         /// <param name="option">The option to get the value from.</param>
         /// <returns>The option's value if it's <c>Some</c>, or <c>null</c> if it's <c>None</c>.</returns>
+        [return: MaybeNull]
         public static T ValueOrNull<T>(this Option<T> option)
             where T : class?
         {

--- a/src/Hamlet/OptionOfT.cs
+++ b/src/Hamlet/OptionOfT.cs
@@ -38,13 +38,6 @@ namespace Hamlet
         public bool IsNone => !IsSome;
 
         /// <summary>
-        /// Attempts to get the option's value, if any, or a default value if the option has no value.
-        /// </summary>
-        /// <param name="defaultValue">The default value to return when the option has no value.</param>
-        /// <returns>The option's value, if any, <c>defaultValue</c> otherwise.</returns>
-        public T GetValueOrDefault(T defaultValue = default) => IsSome ? _value : defaultValue;
-
-        /// <summary>
         /// Attempts to get the option's value, if any.
         /// </summary>
         /// <param name="value">This output parameter will receive the option's value, if any.</param>

--- a/tests/Hamlet.Tests/OptionOfTTests.cs
+++ b/tests/Hamlet.Tests/OptionOfTTests.cs
@@ -51,27 +51,6 @@ namespace Hamlet.Tests
         }
 
         [Fact]
-        public void GetValueOrDefault_returns_value_for_some()
-        {
-            var option = Option.Some(42);
-            option.GetValueOrDefault().Should().Be(42);
-        }
-
-        [Fact]
-        public void GetValueOrDefault_returns_default_for_none()
-        {
-            var option = Option.None<int>();
-            option.GetValueOrDefault().Should().Be(0);
-        }
-
-        [Fact]
-        public void GetValueOrDefault_returns_specified_default_for_none()
-        {
-            var option = Option.None<int>();
-            option.GetValueOrDefault(3).Should().Be(3);
-        }
-
-        [Fact]
         public void TryGetValue_returns_true_and_sets_value_for_some()
         {
             var option = Option.Some(42);

--- a/tests/Hamlet.Tests/OptionTests.cs
+++ b/tests/Hamlet.Tests/OptionTests.cs
@@ -152,6 +152,48 @@ namespace Hamlet.Tests
         }
 
         [Fact]
+        public void GetValueOrDefault_returns_value_for_some()
+        {
+            var option = Option.Some(42);
+            option.GetValueOrDefault().Should().Be(42);
+        }
+
+        [Fact]
+        public void GetValueOrDefault_returns_default_for_none()
+        {
+            var option = Option.None<int>();
+            option.GetValueOrDefault().Should().Be(0);
+        }
+
+        [Fact]
+        public void GetValueOrNull_returns_value_for_some()
+        {
+            var option = Option.Some("hello");
+            option.GetValueOrNull().Should().Be("hello");
+        }
+
+        [Fact]
+        public void GetValueOrNull_returns_null_for_none()
+        {
+            var option = Option.None<string>();
+            option.GetValueOrNull().Should().BeNull();
+        }
+
+        [Fact]
+        public void GetValueOr_returns_value_for_some()
+        {
+            var option = Option.Some(42);
+            option.GetValueOr(3).Should().Be(42);
+        }
+
+        [Fact]
+        public void GetValueOr_returns_default_for_none()
+        {
+            var option = Option.None<int>();
+            option.GetValueOr(3).Should().Be(3);
+        }
+
+        [Fact]
         public void SomeIfNotNull_nullable_returns_none_for_null()
         {
             int? nullable = null;

--- a/tests/Hamlet.Tests/OptionTests.cs
+++ b/tests/Hamlet.Tests/OptionTests.cs
@@ -152,45 +152,45 @@ namespace Hamlet.Tests
         }
 
         [Fact]
-        public void GetValueOrDefault_returns_value_for_some()
+        public void ValueOrDefault_returns_value_for_some()
         {
             var option = Option.Some(42);
-            option.GetValueOrDefault().Should().Be(42);
+            option.ValueOrDefault().Should().Be(42);
         }
 
         [Fact]
-        public void GetValueOrDefault_returns_default_for_none()
+        public void ValueOrDefault_returns_default_for_none()
         {
             var option = Option.None<int>();
-            option.GetValueOrDefault().Should().Be(0);
+            option.ValueOrDefault().Should().Be(0);
         }
 
         [Fact]
-        public void GetValueOrNull_returns_value_for_some()
+        public void ValueOrNull_returns_value_for_some()
         {
             var option = Option.Some("hello");
-            option.GetValueOrNull().Should().Be("hello");
+            option.ValueOrNull().Should().Be("hello");
         }
 
         [Fact]
-        public void GetValueOrNull_returns_null_for_none()
+        public void ValueOrNull_returns_null_for_none()
         {
             var option = Option.None<string>();
-            option.GetValueOrNull().Should().BeNull();
+            option.ValueOrNull().Should().BeNull();
         }
 
         [Fact]
-        public void GetValueOr_returns_value_for_some()
+        public void ValueOr_returns_value_for_some()
         {
             var option = Option.Some(42);
-            option.GetValueOr(3).Should().Be(42);
+            option.ValueOr(3).Should().Be(42);
         }
 
         [Fact]
-        public void GetValueOr_returns_default_for_none()
+        public void ValueOr_returns_default_for_none()
         {
             var option = Option.None<int>();
-            option.GetValueOr(3).Should().Be(3);
+            option.ValueOr(3).Should().Be(3);
         }
 
         [Fact]


### PR DESCRIPTION
This method signature was problematic with C# 8 nullable reference types:

    public T GetValueOrDefault(T defaultValue = default) => IsSome ? _value : defaultValue;

If `T` is a non-nullable reference type, `default` returns null, which isn't a valid value for `T`. This would mislead nullability analysis in a scenario like this:

```csharp
Option<string> option = Option.None<string>();
string value = option.GetValueOrDefault(); // type is string (non-nullable), but value is actually null. No warning!
int length = value.Length; // NullReferenceException
```

Solution: 3 extension methods (so that the constraint can be different depending on the nullability of `T`:

- for value types:
    ```csharp
    public static T ValueOrDefault<T>(this Option<T> option) where T : struct
    ```
    Returns `default(T)` (not nullable) for None.
- for reference types (nullable or not):
    ```csharp
    [return: MaybeNull]
    public static T ValueOrNull<T>(this Option<T> option) where T : class?
    ```
    Returns `null` for None.

- for all types
    ```csharp
    public static T ValueOr<T>(this Option<T> option, T defaultValue)
    ```

    Returns `defaultValue` for None